### PR TITLE
Add a GitHub mobile fallback link for the README video

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Second is a single workspace.
       <h3>Example: <strong>competitor tracker app</strong> built on Second</h3>
       <p>This example features agents discovering new competitors, enriching them, and generating a weekly recap deck from all available information.</p>
       <video src="https://github.com/user-attachments/assets/2116c633-48f3-415a-a047-a72f05da3166" width="600" controls></video>
+      <p><sub>GitHub mobile app? <a href="https://github.com/user-attachments/assets/2116c633-48f3-415a-a047-a72f05da3166">Click here to watch the video →</a></sub></p>
       <p>•</p>
       <p align="left"><strong>Second is the most powerful way to build custom GUIs for agents.</strong><br>Production-ready software for your team, deployed in your VPC, built around your workflows.</p>
       <br>


### PR DESCRIPTION
## Summary
- Keep the existing README video embed for desktop and mobile web viewers
- Add a small centered fallback link below the video so the GitHub mobile app can still open it