### PR TITLE
Improve OpenCode runtime error handling and JSON support detection

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -48,6 +48,7 @@ import {
 } from "./runtimes/index.js";
 import { claudeSubprocessIsolationStatus } from "./runtimes/claude-env.js";
 import { openCodeLocalAuthAvailable } from "./runtimes/process-env.js";
+import { detectOpenCodeRunJsonSupport } from "./runtimes/opencode-cli.js";
 import { discoverOpenCodeModels } from "./runtimes/opencode-models.js";
 
 function resolveWorkspaceDir(appId: string): string {
@@ -910,22 +911,6 @@ function detectBinary(binary: string, versionArgs = ["--version"]) {
   return { available, ...(version ? { version } : {}) };
 }
 
-function binaryHelpIncludes(binary: string, args: string[], expected: string): boolean {
-  const resolved = resolveBinaryPath(binary);
-  if (!resolved) return false;
-
-  try {
-    const result = spawnSync(resolved, args, {
-      timeout: 3000,
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    return `${result.stdout ?? ""}\n${result.stderr ?? ""}`.includes(expected);
-  } catch {
-    return false;
-  }
-}
-
 function codexLocalAuthSeedingEnabled(): boolean {
   return (
     process.env.SECOND_ALLOW_CODEX_LOCAL_AUTH === "1" ||
@@ -984,9 +969,10 @@ app.get("/detect-provider", (c) => {
   const claudeIsolation = claudeSubprocessIsolationStatus();
   const claudeAvailable = claudeCli.available && claudeIsolation.available;
   const codexAuthenticated = codexCli.available && codexCliAuthenticated(codexCommand);
-  const opencodeJsonEvents =
-    opencodeCli.available &&
-    binaryHelpIncludes(opencodeCommand, ["run", "--help"], "--format");
+  const opencodeJsonSupport = opencodeCli.available
+    ? detectOpenCodeRunJsonSupport(opencodeCommand)
+    : null;
+  const opencodeJsonEvents = Boolean(opencodeJsonSupport?.supported);
   const opencodeEnvAuthConfigured = opencodeEnvConfigured();
   const opencodeLocalAuthConfigured = openCodeLocalAuthAvailable();
   const opencodeLikelyConfigured =
@@ -1023,6 +1009,9 @@ app.get("/detect-provider", (c) => {
         ...opencodeCli,
         available: opencodeCli.available && opencodeJsonEvents && opencodeLikelyConfigured,
         features: { jsonEvents: opencodeJsonEvents },
+        ...(!opencodeJsonEvents && opencodeJsonSupport
+          ? { error: opencodeJsonSupport.message }
+          : {}),
         auth: {
           envKeyConfigured: opencodeEnvAuthConfigured,
           cliLikelyConfigured: opencodeLikelyConfigured,
@@ -1040,9 +1029,6 @@ app.get("/detect-provider", (c) => {
 app.get("/opencode/models", (c) => {
   const opencodeCommand = runtimeBinary("SECOND_OPENCODE_PATH", "opencode");
   const opencodeCli = detectBinary(opencodeCommand);
-  const opencodeJsonEvents =
-    opencodeCli.available &&
-    binaryHelpIncludes(opencodeCommand, ["run", "--help"], "--format");
 
   if (!opencodeCli.available) {
     return c.json({
@@ -1055,15 +1041,15 @@ app.get("/opencode/models", (c) => {
     });
   }
 
-  if (!opencodeJsonEvents) {
+  const opencodeJsonSupport = detectOpenCodeRunJsonSupport(opencodeCommand);
+  if (!opencodeJsonSupport.supported && opencodeJsonSupport.definitive) {
     return c.json({
       available: false,
       models: [],
       totalCount: 0,
       filteredOutCount: 0,
       refreshed: false,
-      error:
-        "Installed OpenCode CLI does not support `opencode run --format json`.",
+      error: opencodeJsonSupport.message,
     });
   }
 

--- a/apps/worker/src/runtimes/cli-events.test.ts
+++ b/apps/worker/src/runtimes/cli-events.test.ts
@@ -110,3 +110,62 @@ test("throws when a CLI JSON stream emits a provider error event", async () => {
     /server_is_overloaded: Our servers are currently overloaded/,
   );
 });
+
+test("throws useful text for string-shaped CLI error events", async () => {
+  const script = `
+    console.log(JSON.stringify({
+      type: "error",
+      error: "Provider rejected the selected model."
+    }));
+    setTimeout(() => {}, 1000);
+  `;
+
+  await assert.rejects(
+    async () => {
+      for await (const _message of runJsonlCliRuntime({
+        runtimeId: "opencode",
+        command: process.execPath,
+        args: ["-e", script],
+        cwd: tmpdir(),
+        env: process.env as Record<string, string>,
+        settings,
+      })) {
+        // Drain the stream until it throws.
+      }
+    },
+    /Provider rejected the selected model/,
+  );
+});
+
+test("throws useful text for nested OpenCode runtime error events", async () => {
+  const script = `
+    console.log(JSON.stringify({
+      type: "error",
+      properties: {
+        code: "authentication_failed",
+        data: {
+          error: {
+            message: "Bedrock bearer token is expired."
+          }
+        }
+      }
+    }));
+    setTimeout(() => {}, 1000);
+  `;
+
+  await assert.rejects(
+    async () => {
+      for await (const _message of runJsonlCliRuntime({
+        runtimeId: "opencode",
+        command: process.execPath,
+        args: ["-e", script],
+        cwd: tmpdir(),
+        env: process.env as Record<string, string>,
+        settings,
+      })) {
+        // Drain the stream until it throws.
+      }
+    },
+    /authentication_failed: Bedrock bearer token is expired/,
+  );
+});

--- a/apps/worker/src/runtimes/cli-events.ts
+++ b/apps/worker/src/runtimes/cli-events.ts
@@ -30,6 +30,154 @@ function stringField(record: Record<string, unknown>, key: string): string | nul
   return typeof value === "string" && value ? value : null;
 }
 
+const ERROR_TEXT_KEYS = new Set([
+  "message",
+  "error",
+  "errorMessage",
+  "error_message",
+  "description",
+  "detail",
+  "details",
+  "reason",
+  "stderr",
+  "output",
+  "body",
+]);
+
+const ERROR_CONTAINER_KEYS = new Set([
+  "error",
+  "errors",
+  "data",
+  "cause",
+  "properties",
+  "metadata",
+  "response",
+  "result",
+]);
+
+const ERROR_CODE_KEYS = new Set([
+  "code",
+  "status",
+  "statusCode",
+  "status_code",
+  "name",
+  "type",
+]);
+
+function cleanRuntimeErrorText(value: string): string | null {
+  const trimmed = value.replace(/\u0000/g, "").replace(/\s+/g, " ").trim();
+  if (!trimmed) return null;
+  return trimmed
+    .replace(/\b(sk-[A-Za-z0-9_-]{12,})\b/g, "[redacted-key]")
+    .replace(/\b(AKIA[0-9A-Z]{12,})\b/g, "[redacted-aws-key]")
+    .slice(0, 800);
+}
+
+function parseJsonString(value: string): unknown | null {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function isSensitiveErrorKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return (
+    normalized.includes("token") ||
+    normalized.includes("secret") ||
+    normalized.includes("password") ||
+    normalized.endsWith("apikey") ||
+    normalized.endsWith("api_key") ||
+    normalized === "authorization" ||
+    normalized === "cookie"
+  );
+}
+
+function collectErrorText(
+  value: unknown,
+  key: string,
+  depth = 0,
+): string | null {
+  if (depth > 5 || isSensitiveErrorKey(key)) return null;
+
+  if (typeof value === "string") {
+    const parsed = parseJsonString(value);
+    if (parsed !== null) {
+      const parsedText = collectErrorText(parsed, key, depth + 1);
+      if (parsedText) return parsedText;
+    }
+    return ERROR_TEXT_KEYS.has(key) ? cleanRuntimeErrorText(value) : null;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const text = collectErrorText(item, key, depth + 1);
+      if (text) return text;
+    }
+    return null;
+  }
+
+  const record = asRecord(value);
+  if (Object.keys(record).length === 0) return null;
+
+  const priorityKeys = [
+    "message",
+    "errorMessage",
+    "error_message",
+    "description",
+    "detail",
+    "details",
+    "reason",
+    "error",
+    "errors",
+    "cause",
+    "data",
+    "properties",
+    "response",
+    "result",
+    "stderr",
+    "output",
+    "body",
+  ];
+  for (const childKey of priorityKeys) {
+    if (!(childKey in record)) continue;
+    const text = collectErrorText(record[childKey], childKey, depth + 1);
+    if (text) return text;
+  }
+
+  for (const [childKey, childValue] of Object.entries(record)) {
+    if (!ERROR_CONTAINER_KEYS.has(childKey) && !ERROR_TEXT_KEYS.has(childKey)) {
+      continue;
+    }
+    const text = collectErrorText(childValue, childKey, depth + 1);
+    if (text) return text;
+  }
+
+  return null;
+}
+
+function collectErrorCode(value: unknown, depth = 0): string | null {
+  if (depth > 4) return null;
+  const record = asRecord(value);
+  if (Object.keys(record).length === 0) return null;
+
+  for (const key of ERROR_CODE_KEYS) {
+    const candidate = stringField(record, key);
+    if (candidate && candidate !== "error") return cleanRuntimeErrorText(candidate);
+  }
+
+  for (const key of ERROR_CONTAINER_KEYS) {
+    if (!(key in record)) continue;
+    const code = collectErrorCode(record[key], depth + 1);
+    if (code) return code;
+  }
+
+  return null;
+}
+
 function errorFromJsonEvent(event: unknown): Error | null {
   const record = asRecord(event);
   const type = stringField(record, "type") ?? stringField(record, "event");
@@ -39,13 +187,13 @@ function errorFromJsonEvent(event: unknown): Error | null {
 
   if (type !== "error" && Object.keys(errorRecord).length === 0) return null;
 
-  const code = stringField(errorRecord, "code");
+  const code = collectErrorCode(errorRecord) ?? collectErrorCode(record);
   const message =
-    stringField(errorRecord, "message") ??
-    stringField(rawError, "message") ??
-    stringField(record, "message") ??
+    collectErrorText(errorRecord, "error") ??
+    collectErrorText(record.error, "error") ??
+    collectErrorText(record, "error") ??
     "Runtime emitted an error event.";
-  const details = code ? `${code}: ${message}` : message;
+  const details = code && !message.includes(code) ? `${code}: ${message}` : message;
   return new Error(`${details}`);
 }
 

--- a/apps/worker/src/runtimes/opencode-cli.ts
+++ b/apps/worker/src/runtimes/opencode-cli.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from "node:child_process";
+
+export type OpenCodeJsonSupportProbe =
+  | {
+      supported: true;
+      definitive: true;
+      message?: string;
+    }
+  | {
+      supported: false;
+      definitive: true;
+      reason: "not_found" | "unsupported";
+      message: string;
+    }
+  | {
+      supported: false;
+      definitive: false;
+      reason: "probe_failed";
+      message: string;
+    };
+
+const SUPPORT_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_HELP_TIMEOUT_MS = 10_000;
+
+let jsonSupportCache:
+  | {
+      command: string;
+      expiresAt: number;
+    }
+  | null = null;
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+function helpTimeoutMs(): number {
+  const parsed = Number(process.env.SECOND_OPENCODE_HELP_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_HELP_TIMEOUT_MS;
+}
+
+function spawnErrorCode(error: unknown): string | null {
+  return error && typeof error === "object" && "code" in error
+    ? String((error as { code?: unknown }).code ?? "")
+    : null;
+}
+
+function cacheSupported(command: string): void {
+  jsonSupportCache = {
+    command,
+    expiresAt: Date.now() + SUPPORT_CACHE_TTL_MS,
+  };
+}
+
+export function clearOpenCodeJsonSupportCache(): void {
+  jsonSupportCache = null;
+}
+
+export function detectOpenCodeRunJsonSupport(
+  command: string,
+): OpenCodeJsonSupportProbe {
+  const now = Date.now();
+  if (jsonSupportCache?.command === command && jsonSupportCache.expiresAt > now) {
+    return { supported: true, definitive: true };
+  }
+
+  const result = spawnSync(command, ["run", "--help"], {
+    timeout: helpTimeoutMs(),
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const output = stripAnsi(`${result.stdout ?? ""}\n${result.stderr ?? ""}`);
+
+  if (output.includes("--format")) {
+    cacheSupported(command);
+    return { supported: true, definitive: true };
+  }
+
+  const errorCode = spawnErrorCode(result.error);
+  if (errorCode === "ENOENT") {
+    return {
+      supported: false,
+      definitive: true,
+      reason: "not_found",
+      message: "OpenCode CLI not found.",
+    };
+  }
+
+  if (result.error) {
+    const message =
+      errorCode === "ETIMEDOUT"
+        ? "Timed out while checking whether OpenCode supports JSON events."
+        : `Could not check whether OpenCode supports JSON events: ${result.error.message}`;
+    return {
+      supported: false,
+      definitive: false,
+      reason: "probe_failed",
+      message,
+    };
+  }
+
+  return {
+    supported: false,
+    definitive: true,
+    reason: "unsupported",
+    message:
+      "Installed OpenCode CLI does not support `opencode run --format json`. Upgrade OpenCode before using the OpenCode runtime.",
+  };
+}
+

--- a/apps/worker/src/runtimes/opencode.test.ts
+++ b/apps/worker/src/runtimes/opencode.test.ts
@@ -1,11 +1,26 @@
 import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
+import {
+  clearOpenCodeJsonSupportCache,
+  detectOpenCodeRunJsonSupport,
+} from "./opencode-cli.js";
 import { buildOpenCodeToolConfig } from "./opencode.js";
 import {
   buildOpenCodeRunArgs,
   parseOpenCodeModelsVerbose,
 } from "./opencode-models.js";
 import { openCodeAuthEnvKeysForModel } from "./process-env.js";
+
+function writeProbeScript(contents: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "second-opencode-probe-"));
+  const script = join(dir, "opencode");
+  writeFileSync(script, contents, "utf-8");
+  chmodSync(script, 0o755);
+  return script;
+}
 
 test("OpenCode tool config disables unsupported built-ins for restricted runs", () => {
   const tools = buildOpenCodeToolConfig([
@@ -136,4 +151,84 @@ test("OpenCode Bedrock models receive AWS auth env keys", () => {
       "AWS_SESSION_TOKEN",
     ],
   );
+});
+
+test("OpenCode JSON support probe detects supported run help", () => {
+  clearOpenCodeJsonSupportCache();
+  const command = writeProbeScript(`#!/bin/sh
+echo "opencode run"
+echo "  --format  format: default or json"
+`);
+
+  const result = detectOpenCodeRunJsonSupport(command);
+
+  assert.equal(result.supported, true);
+  assert.equal(result.definitive, true);
+});
+
+test("OpenCode JSON support probe treats completed help without format as unsupported", () => {
+  clearOpenCodeJsonSupportCache();
+  const command = writeProbeScript(`#!/bin/sh
+echo "opencode run"
+echo "  --model  model to use"
+`);
+
+  const result = detectOpenCodeRunJsonSupport(command);
+
+  if (result.supported) assert.fail("expected unsupported OpenCode help");
+  assert.equal(result.definitive, true);
+  assert.equal(result.reason, "unsupported");
+});
+
+test("OpenCode JSON support probe treats timeout as non-definitive", () => {
+  clearOpenCodeJsonSupportCache();
+  const previousTimeout = process.env.SECOND_OPENCODE_HELP_TIMEOUT_MS;
+  process.env.SECOND_OPENCODE_HELP_TIMEOUT_MS = "50";
+  const command = writeProbeScript(`#!/bin/sh
+"${process.execPath}" -e "setTimeout(() => {}, 500)"
+`);
+
+  try {
+    const result = detectOpenCodeRunJsonSupport(command);
+
+    if (result.supported) assert.fail("expected non-definitive probe failure");
+    assert.equal(result.definitive, false);
+    assert.equal(result.reason, "probe_failed");
+  } finally {
+    if (previousTimeout === undefined) {
+      delete process.env.SECOND_OPENCODE_HELP_TIMEOUT_MS;
+    } else {
+      process.env.SECOND_OPENCODE_HELP_TIMEOUT_MS = previousTimeout;
+    }
+  }
+});
+
+test("OpenCode JSON support probe caches positive support", () => {
+  clearOpenCodeJsonSupportCache();
+  const previousTimeout = process.env.SECOND_OPENCODE_HELP_TIMEOUT_MS;
+  const command = writeProbeScript(`#!/bin/sh
+echo "opencode run --format json"
+`);
+
+  try {
+    assert.equal(detectOpenCodeRunJsonSupport(command).supported, true);
+    process.env.SECOND_OPENCODE_HELP_TIMEOUT_MS = "50";
+
+    writeFileSync(
+      command,
+      `#!/bin/sh
+"${process.execPath}" -e "setTimeout(() => {}, 500)"
+`,
+      "utf-8",
+    );
+    chmodSync(command, 0o755);
+
+    assert.equal(detectOpenCodeRunJsonSupport(command).supported, true);
+  } finally {
+    if (previousTimeout === undefined) {
+      delete process.env.SECOND_OPENCODE_HELP_TIMEOUT_MS;
+    } else {
+      process.env.SECOND_OPENCODE_HELP_TIMEOUT_MS = previousTimeout;
+    }
+  }
 });

--- a/apps/worker/src/runtimes/opencode.test.ts
+++ b/apps/worker/src/runtimes/opencode.test.ts
@@ -5,6 +5,7 @@ import {
   buildOpenCodeRunArgs,
   parseOpenCodeModelsVerbose,
 } from "./opencode-models.js";
+import { openCodeAuthEnvKeysForModel } from "./process-env.js";
 
 test("OpenCode tool config disables unsupported built-ins for restricted runs", () => {
   const tools = buildOpenCodeToolConfig([
@@ -118,6 +119,21 @@ test("OpenCode run args include variant only when selected", () => {
       "--session",
       "ses_123",
       "hello",
+    ],
+  );
+});
+
+test("OpenCode Bedrock models receive AWS auth env keys", () => {
+  assert.deepEqual(
+    openCodeAuthEnvKeysForModel("amazon-bedrock/anthropic.claude-opus-4-6-v1"),
+    [
+      "AWS_BEARER_TOKEN_BEDROCK",
+      "AWS_REGION",
+      "AWS_DEFAULT_REGION",
+      "AWS_PROFILE",
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "AWS_SESSION_TOKEN",
     ],
   );
 });

--- a/apps/worker/src/runtimes/opencode.ts
+++ b/apps/worker/src/runtimes/opencode.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { createToolBrokerSession, deleteToolBrokerSession } from "../tool-broker.js";
 import {
@@ -10,6 +9,7 @@ import {
   seedOpenCodeAuthFromLocalLogin,
   writePrivateJsonFile,
 } from "./process-env.js";
+import { detectOpenCodeRunJsonSupport } from "./opencode-cli.js";
 import {
   buildOpenCodeRunArgs,
   resolveOpenCodeVariant,
@@ -54,26 +54,13 @@ function opencodeCommand(): string {
   return process.env.SECOND_OPENCODE_PATH?.trim() || "opencode";
 }
 
-function opencodeRunSupportsJsonFormat(command: string): boolean {
-  try {
-    const help = spawnSync(command, ["run", "--help"], {
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    return `${help.stdout ?? ""}\n${help.stderr ?? ""}`.includes("--format");
-  } catch {
-    return false;
-  }
-}
-
 export const openCodeRuntimeAdapter: RuntimeAdapter = {
   id: "opencode",
   async *run(input) {
     const command = opencodeCommand();
-    if (!opencodeRunSupportsJsonFormat(command)) {
-      throw new Error(
-        "Installed OpenCode CLI does not support `opencode run --format json`. Upgrade OpenCode before using the OpenCode runtime.",
-      );
+    const jsonSupport = detectOpenCodeRunJsonSupport(command);
+    if (!jsonSupport.supported && jsonSupport.definitive) {
+      throw new Error(jsonSupport.message);
     }
 
     const runKey = input.config.runtimeSessionKey ?? input.config.appId ?? "builder";

--- a/apps/worker/src/runtimes/process-env.ts
+++ b/apps/worker/src/runtimes/process-env.ts
@@ -97,6 +97,17 @@ export function openCodeAuthEnvKeysForModel(model: string): string[] {
   const provider = model.split("/")[0]?.toLowerCase();
   if (provider === "openai") return ["OPENAI_API_KEY"];
   if (provider === "anthropic") return ["ANTHROPIC_API_KEY"];
+  if (provider === "amazon-bedrock" || provider === "bedrock" || provider === "aws-bedrock") {
+    return [
+      "AWS_BEARER_TOKEN_BEDROCK",
+      "AWS_REGION",
+      "AWS_DEFAULT_REGION",
+      "AWS_PROFILE",
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "AWS_SESSION_TOKEN",
+    ];
+  }
   if (provider === "google" || provider === "gemini") {
     return ["GOOGLE_API_KEY", "GEMINI_API_KEY"];
   }


### PR DESCRIPTION
## Summary
- Replace the brittle OpenCode `run --help` probe with a dedicated JSON support detector that caches positive results and reports clearer failure reasons.
- Surface more useful runtime error text from nested and string-shaped CLI error events, with basic secret redaction.
- Add Bedrock auth env key support for OpenCode model detection.
- Extend tests for error extraction, JSON support probing, caching, and Bedrock auth env mapping.

## Testing
- Added unit coverage for CLI error extraction and OpenCode JSON support detection.
- Verified the new probe behavior for supported, unsupported, timeout, and cached cases.
- Not run (not requested)