### PR TITLE
Fix release workflow recovery

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -63,11 +63,27 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Check published payload version
+        id: package
+        shell: bash
+        run: |
+          PACKAGE_NAME="$(node -p "require('./${{ matrix.package_dir }}/package.json').name")"
+          VERSION="${{ steps.release.outputs.version }}"
+          echo "name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+          if npm view "${PACKAGE_NAME}@${VERSION}" version --json >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "${PACKAGE_NAME}@${VERSION} already exists; skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set package version
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: npm --prefix "${{ matrix.package_dir }}" pkg set version="${{ steps.release.outputs.version }}"
 
       - name: Install dependencies
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: |
           npm ci --prefix apps/web
@@ -75,6 +91,7 @@ jobs:
           npm ci --prefix packages/cli
 
       - name: Validate
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: |
           npm --prefix packages/cli run build
@@ -82,14 +99,17 @@ jobs:
           npm --prefix apps/worker run typecheck
 
       - name: Build payload
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: npm --prefix "${{ matrix.package_dir }}" run build
 
       - name: Pack check
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: cd "${{ matrix.package_dir }}" && npm pack --dry-run --ignore-scripts
 
       - name: Publish payload
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: cd "${{ matrix.package_dir }}" && npm publish --access public --ignore-scripts
 
@@ -122,24 +142,43 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Check published launcher version
+        id: package
+        shell: bash
+        run: |
+          PACKAGE_NAME="$(node -p "require('./packages/cli/package.json').name")"
+          VERSION="${{ steps.release.outputs.version }}"
+          echo "name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+          if npm view "${PACKAGE_NAME}@${VERSION}" version --json >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "${PACKAGE_NAME}@${VERSION} already exists; skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set package version
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: |
           npm --prefix packages/cli pkg set version="${{ steps.release.outputs.version }}"
           npm --prefix packages/cli install --package-lock-only --ignore-scripts
 
       - name: Install dependencies
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: npm ci --prefix packages/cli
 
       - name: Validate
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: npm --prefix packages/cli run build
 
       - name: Pack check
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: cd packages/cli && npm pack --dry-run --ignore-scripts
 
       - name: Publish launcher
+        if: steps.package.outputs.exists != 'true'
         shell: bash
         run: cd packages/cli && npm publish --access public --ignore-scripts

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -27,9 +27,10 @@ jobs:
           - label: Linux x64
             runner: ubuntu-latest
             package_dir: packages/cli-local-linux-x64
-          - label: Windows x64
-            runner: windows-latest
-            package_dir: packages/cli-local-win32-x64
+          # Windows is not part of the public release yet.
+          # - label: Windows x64
+          #   runner: windows-latest
+          #   package_dir: packages/cli-local-win32-x64
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: second-9r

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -154,8 +154,8 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           TITLE="v${VERSION}"
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" artifacts/Second-mac-arm64.dmg artifacts/Second-mac-arm64.dmg.sha256 --clobber
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" artifacts/Second-mac-arm64.dmg artifacts/Second-mac-arm64.dmg.sha256 --repo "$GITHUB_REPOSITORY" --clobber
           else
-            gh release create "$GITHUB_REF_NAME" artifacts/Second-mac-arm64.dmg artifacts/Second-mac-arm64.dmg.sha256 --title "$TITLE" --notes "Second ${VERSION}"
+            gh release create "$GITHUB_REF_NAME" artifacts/Second-mac-arm64.dmg artifacts/Second-mac-arm64.dmg.sha256 --repo "$GITHUB_REPOSITORY" --title "$TITLE" --notes "Second ${VERSION}"
           fi

--- a/packages/cli/bin/second.js
+++ b/packages/cli/bin/second.js
@@ -124,13 +124,14 @@ function resolvePayloadPackage() {
       binName: "second-local",
     };
   }
-  if (runtimeId === "win32-x64") {
-    return {
-      runtimeId,
-      packageName: "@second-inc/cli-local-win32-x64",
-      binName: "second-local",
-    };
-  }
+  // Windows is not part of the public release yet.
+  // if (runtimeId === "win32-x64") {
+  //   return {
+  //     runtimeId,
+  //     packageName: "@second-inc/cli-local-win32-x64",
+  //     binName: "second-local",
+  //   };
+  // }
   return null;
 }
 
@@ -416,11 +417,11 @@ function printUnsupportedPlatform() {
     eyebrow: "unsupported platform",
     title: "Second is not available here yet",
     subtitle:
-      "The local installer currently ships for macOS, Linux x64, and Windows x64.",
+      "The local installer currently ships for macOS and Linux x64.",
     quote: "\"Detected a runtime we do not package yet.\"",
     rows: [
       ["detected", currentRuntimeId()],
-      ["supported", "darwin-arm64, darwin-x64, linux-x64, win32-x64"],
+      ["supported", "darwin-arm64, darwin-x64, linux-x64"],
     ],
     tone: "error",
   });


### PR DESCRIPTION
Fixes two release issues from v0.1.33:

- Desktop release upload now passes the repo explicitly to gh release, so the artifact attach job works without a checkout.
- CLI release jobs now skip package versions that already exist on npm, so a partially-published release can be safely rerun after npm package setup is fixed.

Manual npm setup is still required for missing platform packages/trusted publishers before the next real release.