### PR TITLE
Handle immutable desktop releases

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -154,8 +154,21 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           TITLE="v${VERSION}"
-          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" artifacts/Second-mac-arm64.dmg artifacts/Second-mac-arm64.dmg.sha256 --repo "$GITHUB_REPOSITORY" --clobber
-          else
-            gh release create "$GITHUB_REF_NAME" artifacts/Second-mac-arm64.dmg artifacts/Second-mac-arm64.dmg.sha256 --repo "$GITHUB_REPOSITORY" --title "$TITLE" --notes "Second ${VERSION}"
+
+          if RELEASE_JSON="$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft,isImmutable 2>/dev/null)"; then
+            IS_DRAFT="$(jq -r '.isDraft' <<< "$RELEASE_JSON")"
+            IS_IMMUTABLE="$(jq -r '.isImmutable' <<< "$RELEASE_JSON")"
+
+            if [[ "$IS_DRAFT" == "true" ]]; then
+              gh release upload "$GITHUB_REF_NAME" artifacts/Second-mac-arm64.dmg artifacts/Second-mac-arm64.dmg.sha256 --repo "$GITHUB_REPOSITORY" --clobber
+              gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false --latest --title "$TITLE" --notes "Second ${VERSION}"
+            elif [[ "$IS_IMMUTABLE" == "true" ]]; then
+              echo "::error::Release $GITHUB_REF_NAME is already published and immutable, so assets cannot be attached. Delete the GitHub Release and rerun this job, or create releases as drafts before this workflow runs."
+              exit 1
+            else
+              gh release upload "$GITHUB_REF_NAME" artifacts/Second-mac-arm64.dmg artifacts/Second-mac-arm64.dmg.sha256 --repo "$GITHUB_REPOSITORY" --clobber
+            fi
+            exit 0
           fi
+
+          gh release create "$GITHUB_REF_NAME" artifacts/Second-mac-arm64.dmg artifacts/Second-mac-arm64.dmg.sha256 --repo "$GITHUB_REPOSITORY" --title "$TITLE" --notes "Second ${VERSION}"


### PR DESCRIPTION
Fixes the desktop release asset upload path for repos with immutable releases enabled.

What changed:
- If no GitHub Release exists, keep creating the release with DMG assets in the initial create path.
- If a draft release exists, upload the DMG assets and publish it.
- If a published immutable release already exists, fail with a clear error instead of trying an impossible asset upload.

This prevents the confusing HTTP 422 immutable release failure and supports a safe draft-release flow.